### PR TITLE
Fix missed , in __all__

### DIFF
--- a/pika_pool.py
+++ b/pika_pool.py
@@ -70,9 +70,9 @@ import pika.exceptions
 __version__ = '0.1.2'
 
 __all__ = [
-    'Error'
-    'Timeout'
-    'Overflow'
+    'Error',
+    'Timeout',
+    'Overflow',
     'Connection',
     'Pool',
     'NullPool',


### PR DESCRIPTION
Working on [a version of pika-pool for my own amqp library](https://github.com/eandersson/amqpstorm-pool) I noticed that the `__all__ `list is missing `,` for some items.